### PR TITLE
Add title to formatter

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -77,13 +77,13 @@ Styling
 +++++++
 
 If you wish to have a colour bar next to each message reflecting the logging
-severity, you need to use the `SlackFormatter` and attach it to your handler:
+severity, you need to use the `SlackFormatter` and attach it to your handler. The title parameter is optional.
 
 .. code-block:: python
 
     from webhook_logger.slack import SlackFormatter
 
-    h.formatter = SlackFormatter()
+    h.formatter = SlackFormatter(title='Some slack title')
 
     # Green border
     logger.info("Hello World")

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -126,6 +126,7 @@ features described above:
         'formatters': {
             'slack_format': {
                 '()': 'webhook_logger.slack.SlackFormatter',
+                'title': 'Your optional title'
             },
         },
         'loggers': {

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -22,6 +22,7 @@ DICT_CONFIG = {
     'formatters': {
         'slack_format': {
             '()': 'webhook_logger.slack.SlackFormatter',
+            'title': 'title'
         },
     },
     'handlers': {
@@ -139,7 +140,7 @@ class TestSlackLogging(unittest.TestCase):
 
         logger.info("Test with dictConfig", extra={'notify_slack': True})
         self.assertEqual(self.rm.call_count, 1)
-        self._assert_has_attachment("Test with dictConfig", "good")
+        self._assert_has_attachment("Test with dictConfig", "good", "title")
 
     @mock.patch('webhook_logger.slack.SlackHandler.handleError')
     def test_connection_error(self, error_handler):

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -51,12 +51,13 @@ class TestSlackLogging(unittest.TestCase):
     def tearDown(self):
         self.rm.stop()
 
-    def _build_logger(self, name, url=None, filter=False, formatter=False,
+    @staticmethod
+    def _build_logger(name, url=None, log_filter=False, formatter=False,
                       formatter_title=None):
         logger = logging.getLogger(name)
         logger.setLevel(logging.DEBUG)
         h = SlackHandler(hook_url=url)
-        if filter:
+        if log_filter:
             h.addFilter(SlackLogFilter())
         if formatter:
             h.formatter = SlackFormatter(formatter_title)
@@ -86,13 +87,13 @@ class TestSlackLogging(unittest.TestCase):
 
     def test_filtering_out(self):
         self.rm.post('https://some-hook.com/abcde', text='ok')
-        logger = self._build_logger('filter_out', 'https://some-hook.com/abcde', filter=True)
+        logger = self._build_logger('filter_out', 'https://some-hook.com/abcde', log_filter=True)
         logger.info("test filtering")
         self.assertEqual(self.rm.call_count, 0)
 
     def test_filtering_in(self):
         self.rm.post('https://some-hook.com/abcde', text='ok')
-        logger = self._build_logger('filter_in', 'https://some-hook.com/abcde', filter=True)
+        logger = self._build_logger('filter_in', 'https://some-hook.com/abcde', log_filter=True)
         logger.info("test filtering", extra={'notify_slack': True})
         self.assertEqual(self.rm.call_count, 1)
         self.assertEqual(self.rm.last_request.body.decode(), '{"text": "test filtering"}')

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -50,7 +50,8 @@ class TestSlackLogging(unittest.TestCase):
     def tearDown(self):
         self.rm.stop()
 
-    def _build_logger(self, name, url=None, filter=False, formatter=False, formatter_title=None):
+    def _build_logger(self, name, url=None, filter=False, formatter=False,
+                      formatter_title=None):
         logger = logging.getLogger(name)
         logger.setLevel(logging.DEBUG)
         h = SlackHandler(hook_url=url)
@@ -109,7 +110,9 @@ class TestSlackLogging(unittest.TestCase):
 
     def test_formatter(self):
         self.rm.post('https://some-formatted-hook.com/xyz', text='ok')
-        logger = self._build_logger('formatted_on', 'https://some-formatted-hook.com/xyz', formatter=True,
+        logger = self._build_logger('formatted_on',
+                                    'https://some-formatted-hook.com/xyz',
+                                    formatter=True,
                                     formatter_title='title')
 
         logger.debug("Test debugging")

--- a/webhook_logger/slack.py
+++ b/webhook_logger/slack.py
@@ -66,7 +66,7 @@ class SimpleSlackFormatter(logging.Formatter):
 class SlackFormatter(logging.Formatter):
 
     def __init__(self, title=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(SlackFormatter, self).__init__(*args, **kwargs)
         self.title = title
 
     def format(self, record):

--- a/webhook_logger/slack.py
+++ b/webhook_logger/slack.py
@@ -64,6 +64,11 @@ class SimpleSlackFormatter(logging.Formatter):
 
 
 class SlackFormatter(logging.Formatter):
+
+    def __init__(self, title=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.title = title
+
     def format(self, record):
         """
         Format message content, timestamp when it was logged and a
@@ -72,6 +77,7 @@ class SlackFormatter(logging.Formatter):
         ret = {
             'ts': record.created,
             'text': record.getMessage(),
+            'title': self.title
         }
         try:
             loglevel_colour = {


### PR DESCRIPTION
It is possible to pass a title to the formatter. I do use a single slack channel for multiple instances of the same project and I would like to see from which instance a message is. I've added an optinal 'title' parameter to the formatter which adds this to the attachment.  For more info see https://api.slack.com/incoming-webhooks#advanced_message_formatting